### PR TITLE
fix: handle long email lists and bypass Cloudflare challenge

### DIFF
--- a/lib/lambda/call-api.ts
+++ b/lib/lambda/call-api.ts
@@ -22,7 +22,8 @@ const postChunk = async (chunk: Mail[], apiToken: string) => {
             headers: {
                 'Accept': 'application/json',
                 'Content-Type': 'application/json',
-                'Authorization': `Bearer ${apiToken}`
+                'Authorization': `Bearer ${apiToken}`,
+                'custom-source': 'aws'
             },
             body: JSON.stringify(chunk)
         });

--- a/lib/lambda/s3-processor.ts
+++ b/lib/lambda/s3-processor.ts
@@ -1,6 +1,7 @@
 import { getMailByDates } from './handler/mail-service';
 import { Mail } from './entry/mail';
 import { publishError } from './helpers';
+import { splitS3Url } from './handler/utils';
 
 
 export const handler = async (event: any) => {
@@ -19,7 +20,7 @@ export const handler = async (event: any) => {
         const mails = await getMailByDates(startISO, endISO);
 
         const images = mails?.filter((mail: Mail) => !!mail.image_path).map((mail: Mail) => ({
-            s3Key: mail.image_path,
+            s3Key: splitS3Url(mail.image_path)?.key,
         })) || [];
 
         return { images };


### PR DESCRIPTION
Summary
- Long email lists in one request – Optimizes handling of lengthy email lists to prevent performance bottlenecks or truncation.
- Cloudflare access – Implements a workaround to bypass Cloudflare challenges when making automated requests.

Changes
- Improved processing of long email lists to ensure efficient handling.
- Added logic to bypass Cloudflare challenges, ensuring successful API requests.

Testing
- [ ] Verified email lists of varying lengths process correctly.
- [ ] Tested Cloudflare-protected requests to confirm successful access.
- [ ]  Checked for regressions in related functionalities.